### PR TITLE
Persist workspace (VarName & Expression) across sessions

### DIFF
--- a/src/config.pas
+++ b/src/config.pas
@@ -24,8 +24,9 @@ const
   APP_TITLE = '2 + 3';
 
   DATA_DIR                = APP_NAME;
-  HISTORY_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'history.2p3');
-  VARS_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'variables.2p3');
+  HISTORY_FILE: TDataFile   = (Dirname: DATA_DIR; Filename: 'history.2p3');
+  VARS_FILE: TDataFile      = (Dirname: DATA_DIR; Filename: 'variables.2p3');
+  WORKSPACE_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'workspace.2p3');
 
   HOT_KEY: THotKey = (ModKey: MOD_ALT; VirtualKey: VK_K);
 

--- a/src/form/mainform.lfm
+++ b/src/form/mainform.lfm
@@ -28,6 +28,7 @@ object Calculator: TCalculator
     ParentBidiMode = False
     ParentFont = False
     TabOrder = 1
+    OnChange = ExpressionChange
     OnKeyDown = ExpressionKeyDown
   end
   object VarName: TEdit
@@ -45,6 +46,7 @@ object Calculator: TCalculator
     ParentFont = False
     TabOrder = 0
     Text = 'XYZ'
+    OnChange = VarNameChange
     OnKeyDown = VarNameKeyDown
   end
   object StatusBar: TStatusBar

--- a/src/form/mainform.pas
+++ b/src/form/mainform.pas
@@ -32,7 +32,9 @@ type
     procedure FormShow(Sender: TObject);
 
     procedure ExpressionKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure ExpressionChange(Sender: TObject);
     procedure VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure VarNameChange(Sender: TObject);
     procedure HistoryKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure HistoryDblClick(Sender: TObject);
     procedure VariableListKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -145,6 +147,16 @@ end;
 procedure TCalculator.GridMouseWheelUp(Sender: TObject; Shift: TShiftState; MousePos: TPoint; var Handled: Boolean);
 begin
   GridUtils.StringGridMouseWheelUp(Sender as TStringGrid, Shift, MousePos, Handled);
+end;
+
+procedure TCalculator.ExpressionChange(Sender: TObject);
+begin
+  CalcService.SaveWorkspace;
+end;
+
+procedure TCalculator.VarNameChange(Sender: TObject);
+begin
+  CalcService.SaveWorkspace;
 end;
 
 procedure TCalculator.VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -48,7 +48,7 @@ implementation
 
 uses
   SysUtils, Windows, Controls, StdCtrls, ComCtrls, Grids,
-  Config, ExprService, DataDir, FormUtils, GridUtils, CsvDocument;
+  Config, ExprService, DataDir, FormUtils, GridUtils, Workspace;
 
 var
   _History:    TStringGrid;
@@ -431,48 +431,8 @@ begin
 end;
 
 procedure SaveWorkspace;
-const
-  COL_KEY   = 0;
-  COL_VALUE = 1;
-  ROW_HEADER    = 0;
-  ROW_VARNAME    = 1;
-  ROW_EXPRESSION = 2;
-var
-  CSV:         TCSVDocument;
-  PathFilename: String;
-  TmpFilename: String;
 begin
-    try
-      begin
-      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
-      TmpFilename  := PathFilename + '.tmp';
-
-      CSV           := TCSVDocument.Create;
-      CSV.Delimiter := ',';
-        try
-          begin
-          CSV.Cells[COL_KEY, ROW_HEADER]    := 'key';
-          CSV.Cells[COL_VALUE, ROW_HEADER]  := 'value';
-          CSV.Cells[COL_KEY, ROW_VARNAME]   := 'varname';
-          CSV.Cells[COL_VALUE, ROW_VARNAME] := _VarName.Text;
-          CSV.Cells[COL_KEY, ROW_EXPRESSION]   := 'expression';
-          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := _Expression.Text;
-          CSV.SaveToFile(TmpFilename);
-          end;
-        finally
-          begin
-          CSV.Free;
-          end;
-        end;
-
-      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
-        begin
-        SysUtils.DeleteFile(TmpFilename);
-        end;
-      end;
-    except
-      // Workspace save is best-effort; never surface errors to the user
-    end;
+  Workspace.SaveWorkspace(_VarName.Text, _Expression.Text);
 end;
 
 procedure SetFocus;
@@ -498,8 +458,7 @@ end;
 
 procedure Initialize;
 var
-  PathFilename: String;
-  CSV:          TCSVDocument;
+  WS: TWorkspaceState;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -516,6 +475,10 @@ begin
       LoadGrid(_VarList, VARS_FILE);
       UpsertVarList;
 
+      WS               := Workspace.LoadWorkspace;
+      _VarName.Text    := WS.VarName;
+      _Expression.Text := WS.Expression;
+
       StatusOK;
       end;
     except
@@ -523,39 +486,6 @@ begin
       begin
       StatusError(E.Message);
       end;
-    end;
-
-  // Restore workspace (best-effort, errors silently ignored)
-    try
-      begin
-      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
-
-      // Clean up any stale temp file from a previous crashed save
-      if SysUtils.FileExists(PathFilename + '.tmp') then
-        SysUtils.DeleteFile(PathFilename + '.tmp');
-
-      if SysUtils.FileExists(PathFilename) then
-        begin
-        CSV           := TCSVDocument.Create;
-        CSV.Delimiter := ',';
-          try
-            begin
-            CSV.LoadFromFile(PathFilename);
-            // Row 0 is the header; data starts at row 1
-            if CSV.RowCount > 1 then
-              _VarName.Text := CSV.Cells[1, 1];
-            if CSV.RowCount > 2 then
-              _Expression.Text := CSV.Cells[1, 2];
-            end;
-          finally
-            begin
-            CSV.Free;
-            end;
-          end;
-        end;
-      end;
-    except
-      // Workspace restore is best-effort
     end;
 end;
 

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -38,6 +38,8 @@ procedure RemoveHistoryItem;
 
 procedure SetFocus;
 
+procedure SaveWorkspace;
+
 procedure Receive(const F: TCalculator);
 procedure Initialize;
 
@@ -46,7 +48,7 @@ implementation
 
 uses
   SysUtils, Windows, Controls, StdCtrls, ComCtrls, Grids,
-  Config, ExprService, DataDir, FormUtils, GridUtils;
+  Config, ExprService, DataDir, FormUtils, GridUtils, CsvDocument;
 
 var
   _History:    TStringGrid;
@@ -54,6 +56,7 @@ var
   _Expression: TEdit;
   _VarList:    TStringGrid;
   _StatusBar:  TStatusBar;
+  FocusSet:    Boolean;
 
   {================ Private routines ================}
 
@@ -427,8 +430,50 @@ begin
     end;
 end;
 
+procedure SaveWorkspace;
+const
+  COL_KEY   = 0;
+  COL_VALUE = 1;
+  ROW_HEADER    = 0;
+  ROW_VARNAME    = 1;
+  ROW_EXPRESSION = 2;
 var
-  FocusSet: Boolean;
+  CSV:         TCSVDocument;
+  PathFilename: String;
+  TmpFilename: String;
+begin
+    try
+      begin
+      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+      TmpFilename  := PathFilename + '.tmp';
+
+      CSV           := TCSVDocument.Create;
+      CSV.Delimiter := ',';
+        try
+          begin
+          CSV.Cells[COL_KEY, ROW_HEADER]    := 'key';
+          CSV.Cells[COL_VALUE, ROW_HEADER]  := 'value';
+          CSV.Cells[COL_KEY, ROW_VARNAME]   := 'varname';
+          CSV.Cells[COL_VALUE, ROW_VARNAME] := _VarName.Text;
+          CSV.Cells[COL_KEY, ROW_EXPRESSION]   := 'expression';
+          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := _Expression.Text;
+          CSV.SaveToFile(TmpFilename);
+          end;
+        finally
+          begin
+          CSV.Free;
+          end;
+        end;
+
+      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
+        begin
+        SysUtils.DeleteFile(TmpFilename);
+        end;
+      end;
+    except
+      // Workspace save is best-effort; never surface errors to the user
+    end;
+end;
 
 procedure SetFocus;
 begin
@@ -452,6 +497,9 @@ begin
 end;
 
 procedure Initialize;
+var
+  PathFilename: String;
+  CSV:          TCSVDocument;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -475,6 +523,39 @@ begin
       begin
       StatusError(E.Message);
       end;
+    end;
+
+  // Restore workspace (best-effort, errors silently ignored)
+    try
+      begin
+      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+
+      // Clean up any stale temp file from a previous crashed save
+      if SysUtils.FileExists(PathFilename + '.tmp') then
+        SysUtils.DeleteFile(PathFilename + '.tmp');
+
+      if SysUtils.FileExists(PathFilename) then
+        begin
+        CSV           := TCSVDocument.Create;
+        CSV.Delimiter := ',';
+          try
+            begin
+            CSV.LoadFromFile(PathFilename);
+            // Row 0 is the header; data starts at row 1
+            if CSV.RowCount > 1 then
+              _VarName.Text := CSV.Cells[1, 1];
+            if CSV.RowCount > 2 then
+              _Expression.Text := CSV.Cells[1, 2];
+            end;
+          finally
+            begin
+            CSV.Free;
+            end;
+          end;
+        end;
+      end;
+    except
+      // Workspace restore is best-effort
     end;
 end;
 

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -1,0 +1,111 @@
+unit Workspace;
+
+{$mode ObjFPC}
+{$H+}
+{$inline ON}
+
+interface
+
+type
+  TWorkspaceState = record
+    VarName:    String;
+    Expression: String;
+  end;
+
+procedure SaveWorkspace(const VarName, Expression: String);
+function LoadWorkspace: TWorkspaceState;
+
+implementation
+
+uses
+  SysUtils, Windows, CsvDocument,
+  Config, DataDir;
+
+const
+  COL_KEY        = 0;
+  COL_VALUE      = 1;
+  ROW_HEADER     = 0;
+  ROW_VARNAME    = 1;
+  ROW_EXPRESSION = 2;
+
+procedure SaveWorkspace(const VarName, Expression: String);
+var
+  CSV:          TCSVDocument;
+  PathFilename: String;
+  TmpFilename:  String;
+begin
+    try
+      begin
+      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+      TmpFilename  := PathFilename + '.tmp';
+
+      CSV           := TCSVDocument.Create;
+      CSV.Delimiter := ',';
+        try
+          begin
+          CSV.Cells[COL_KEY,   ROW_HEADER]     := 'key';
+          CSV.Cells[COL_VALUE, ROW_HEADER]     := 'value';
+          CSV.Cells[COL_KEY,   ROW_VARNAME]    := 'varname';
+          CSV.Cells[COL_VALUE, ROW_VARNAME]    := VarName;
+          CSV.Cells[COL_KEY,   ROW_EXPRESSION] := 'expression';
+          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := Expression;
+          CSV.SaveToFile(TmpFilename);
+          end;
+        finally
+          begin
+          CSV.Free;
+          end;
+        end;
+
+      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
+        begin
+        SysUtils.DeleteFile(TmpFilename);
+        end;
+      end;
+    except
+      // Save is best-effort; never surface errors to the user
+    end;
+end;
+
+function LoadWorkspace: TWorkspaceState;
+var
+  PathFilename: String;
+  CSV:          TCSVDocument;
+begin
+  Result.VarName    := '';
+  Result.Expression := '';
+
+    try
+      begin
+      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+
+      // Clean up any stale temp file from a previous crashed save
+      if SysUtils.FileExists(PathFilename + '.tmp') then
+        SysUtils.DeleteFile(PathFilename + '.tmp');
+
+      if SysUtils.FileExists(PathFilename) then
+        begin
+        CSV           := TCSVDocument.Create;
+        CSV.Delimiter := ',';
+          try
+            begin
+            CSV.LoadFromFile(PathFilename);
+            // Row 0 is the header; data starts at row 1
+            if CSV.RowCount > ROW_VARNAME then
+              Result.VarName := CSV.Cells[COL_VALUE, ROW_VARNAME];
+            if CSV.RowCount > ROW_EXPRESSION then
+              Result.Expression := CSV.Cells[COL_VALUE, ROW_EXPRESSION];
+            end;
+          finally
+            begin
+            CSV.Free;
+            end;
+          end;
+        end;
+      end;
+    except
+      // Load is best-effort; return empty defaults on any error
+    end;
+end;
+
+end.

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -24,9 +24,8 @@ uses
 const
   COL_KEY        = 0;
   COL_VALUE      = 1;
-  ROW_HEADER     = 0;
-  ROW_VARNAME    = 1;
-  ROW_EXPRESSION = 2;
+  ROW_VARNAME    = 0;
+  ROW_EXPRESSION = 1;
 
 procedure SaveWorkspace(const VarName, Expression: String);
 var
@@ -43,8 +42,6 @@ begin
       CSV.Delimiter := ',';
         try
           begin
-          CSV.Cells[COL_KEY,   ROW_HEADER]     := 'key';
-          CSV.Cells[COL_VALUE, ROW_HEADER]     := 'value';
           CSV.Cells[COL_KEY,   ROW_VARNAME]    := 'varname';
           CSV.Cells[COL_VALUE, ROW_VARNAME]    := VarName;
           CSV.Cells[COL_KEY,   ROW_EXPRESSION] := 'expression';


### PR DESCRIPTION
Closes #3.

## Summary

- Save the current variable name and expression to `workspace.2p3` on every change using an atomic write (tmp + `MoveFileEx` rename); restore them in `CalcService.Initialize` on next startup.
- Refactor: extract `SaveWorkspace` / `LoadWorkspace` logic out of `CalcService` into a new `src/utils/workspace.pas` unit with a `TWorkspaceState` record.
- Simplify the file format: remove the header row so `workspace.2p3` contains only the two data rows (varname, expression).

## Commits
1. Persist VarName and Expression across sessions (closes #3)
2. Extract workspace persistence into Workspace unit
3. Remove header row from workspace.2p3