### PR TITLE
Persist and restore window position

### DIFF
--- a/src/config.pas
+++ b/src/config.pas
@@ -24,8 +24,9 @@ const
   APP_TITLE = '2 + 3';
 
   DATA_DIR                = APP_NAME;
-  HISTORY_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'history.2p3');
-  VARS_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'variables.2p3');
+  HISTORY_FILE: TDataFile   = (Dirname: DATA_DIR; Filename: 'history.2p3');
+  VARS_FILE: TDataFile      = (Dirname: DATA_DIR; Filename: 'variables.2p3');
+  WORKSPACE_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'workspace.2p3');
 
   HOT_KEY: THotKey = (ModKey: MOD_ALT; VirtualKey: VK_K);
 

--- a/src/config.pas
+++ b/src/config.pas
@@ -27,6 +27,7 @@ const
   HISTORY_FILE: TDataFile   = (Dirname: DATA_DIR; Filename: 'history.2p3');
   VARS_FILE: TDataFile      = (Dirname: DATA_DIR; Filename: 'variables.2p3');
   WORKSPACE_FILE: TDataFile = (Dirname: DATA_DIR; Filename: 'workspace.2p3');
+  WINPOS_FILE: TDataFile    = (Dirname: DATA_DIR; Filename: 'winpos.2p3');
 
   HOT_KEY: THotKey = (ModKey: MOD_ALT; VirtualKey: VK_K);
 

--- a/src/form/mainform.lfm
+++ b/src/form/mainform.lfm
@@ -28,6 +28,7 @@ object Calculator: TCalculator
     ParentBidiMode = False
     ParentFont = False
     TabOrder = 1
+    OnChange = ExpressionChange
     OnKeyDown = ExpressionKeyDown
   end
   object VarName: TEdit
@@ -45,6 +46,7 @@ object Calculator: TCalculator
     ParentFont = False
     TabOrder = 0
     Text = 'XYZ'
+    OnChange = VarNameChange
     OnKeyDown = VarNameKeyDown
   end
   object StatusBar: TStatusBar

--- a/src/form/mainform.lfm
+++ b/src/form/mainform.lfm
@@ -12,6 +12,8 @@ object Calculator: TCalculator
   OnClose = FormClose
   OnCreate = FormCreate
   OnDestroy = FormDestroy
+  OnMove = FormMove
+  OnResize = FormResize
   OnShow = FormShow
   object Expression: TEdit
     Left = 96

--- a/src/form/mainform.pas
+++ b/src/form/mainform.pas
@@ -35,6 +35,8 @@ type
     procedure ExpressionChange(Sender: TObject);
     procedure VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure VarNameChange(Sender: TObject);
+    procedure FormMove(Sender: TObject; var NewLeft, NewTop: Integer);
+    procedure FormResize(Sender: TObject);
     procedure HistoryKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure HistoryDblClick(Sender: TObject);
     procedure VariableListKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -157,6 +159,16 @@ end;
 procedure TCalculator.VarNameChange(Sender: TObject);
 begin
   CalcService.SaveWorkspace;
+end;
+
+procedure TCalculator.FormMove(Sender: TObject; var NewLeft, NewTop: Integer);
+begin
+  CalcService.SaveWindowPos;
+end;
+
+procedure TCalculator.FormResize(Sender: TObject);
+begin
+  CalcService.SaveWindowPos;
 end;
 
 procedure TCalculator.VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);

--- a/src/form/mainform.pas
+++ b/src/form/mainform.pas
@@ -32,7 +32,9 @@ type
     procedure FormShow(Sender: TObject);
 
     procedure ExpressionKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure ExpressionChange(Sender: TObject);
     procedure VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure VarNameChange(Sender: TObject);
     procedure HistoryKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure HistoryDblClick(Sender: TObject);
     procedure VariableListKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -145,6 +147,16 @@ end;
 procedure TCalculator.GridMouseWheelUp(Sender: TObject; Shift: TShiftState; MousePos: TPoint; var Handled: Boolean);
 begin
   GridUtils.StringGridMouseWheelUp(Sender as TStringGrid, Shift, MousePos, Handled);
+end;
+
+procedure TCalculator.ExpressionChange(Sender: TObject);
+begin
+  CalcService.SaveWorkspace;
+end;
+
+procedure TCalculator.VarNameChange(Sender: TObject);
+begin
+  CalcService.SaveWorkspace;
 end;
 
 procedure TCalculator.VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -48,7 +48,7 @@ implementation
 
 uses
   SysUtils, Windows, Controls, StdCtrls, ComCtrls, Grids,
-  Config, ExprService, DataDir, FormUtils, GridUtils, CsvDocument;
+  Config, ExprService, DataDir, FormUtils, GridUtils, Workspace;
 
 var
   _History:    TStringGrid;
@@ -431,48 +431,8 @@ begin
 end;
 
 procedure SaveWorkspace;
-const
-  COL_KEY   = 0;
-  COL_VALUE = 1;
-  ROW_HEADER    = 0;
-  ROW_VARNAME    = 1;
-  ROW_EXPRESSION = 2;
-var
-  CSV:         TCSVDocument;
-  PathFilename: String;
-  TmpFilename: String;
 begin
-    try
-      begin
-      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
-      TmpFilename  := PathFilename + '.tmp';
-
-      CSV           := TCSVDocument.Create;
-      CSV.Delimiter := ',';
-        try
-          begin
-          CSV.Cells[COL_KEY, ROW_HEADER]    := 'key';
-          CSV.Cells[COL_VALUE, ROW_HEADER]  := 'value';
-          CSV.Cells[COL_KEY, ROW_VARNAME]   := 'varname';
-          CSV.Cells[COL_VALUE, ROW_VARNAME] := _VarName.Text;
-          CSV.Cells[COL_KEY, ROW_EXPRESSION]   := 'expression';
-          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := _Expression.Text;
-          CSV.SaveToFile(TmpFilename);
-          end;
-        finally
-          begin
-          CSV.Free;
-          end;
-        end;
-
-      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
-        begin
-        SysUtils.DeleteFile(TmpFilename);
-        end;
-      end;
-    except
-      // Workspace save is best-effort; never surface errors to the user
-    end;
+  Workspace.SaveWorkspace(_VarName.Text, _Expression.Text);
 end;
 
 procedure SetFocus;
@@ -498,8 +458,7 @@ end;
 
 procedure Initialize;
 var
-  PathFilename: String;
-  CSV:          TCSVDocument;
+  WS: TWorkspaceState;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -516,6 +475,10 @@ begin
       LoadGrid(_VarList, VARS_FILE);
       UpsertVarList;
 
+      WS               := Workspace.LoadWorkspace;
+      _VarName.Text    := WS.VarName;
+      _Expression.Text := WS.Expression;
+
       StatusOK;
       end;
     except
@@ -523,39 +486,6 @@ begin
       begin
       StatusError(E.Message);
       end;
-    end;
-
-  // Restore workspace (best-effort, errors silently ignored)
-    try
-      begin
-      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
-
-      // Clean up any stale temp file from a previous crashed save
-      if SysUtils.FileExists(PathFilename + '.tmp') then
-        SysUtils.DeleteFile(PathFilename + '.tmp');
-
-      if SysUtils.FileExists(PathFilename) then
-        begin
-        CSV           := TCSVDocument.Create;
-        CSV.Delimiter := ',';
-          try
-            begin
-            CSV.LoadFromFile(PathFilename);
-            // Row 0 is the header; data starts at row 1
-            if CSV.RowCount > 1 then
-              _VarName.Text := CSV.Cells[1, 1];
-            if CSV.RowCount > 2 then
-              _Expression.Text := CSV.Cells[1, 2];
-            end;
-          finally
-            begin
-            CSV.Free;
-            end;
-          end;
-        end;
-      end;
-    except
-      // Workspace restore is best-effort
     end;
 end;
 

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -439,7 +439,7 @@ end;
 
 procedure SaveWindowPos;
 begin
-  Workspace.SaveWindowPos(_Form.Left, _Form.Top, _Form.Width, _Form.Height);
+  Workspace.SaveWindowPos(_Form.BoundsRect);
 end;
 
 procedure SetFocus;
@@ -467,7 +467,7 @@ end;
 procedure Initialize;
 var
   WS: TWorkspaceState;
-  WP: TWindowPos;
+  WP: TRect;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -489,9 +489,9 @@ begin
       _Expression.Text := WS.Expression;
 
       WP := Workspace.AdjustWindowPos(Workspace.LoadWindowPos);
-      if (WP.Width > 0) and (WP.Height > 0) then
+      if (WP.Right > WP.Left) and (WP.Bottom > WP.Top) then
         begin
-        _Form.SetBounds(WP.Left, WP.Top, WP.Width, WP.Height);
+        _Form.BoundsRect := WP;
         end;
 
       StatusOK;

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -38,6 +38,8 @@ procedure RemoveHistoryItem;
 
 procedure SetFocus;
 
+procedure SaveWorkspace;
+
 procedure Receive(const F: TCalculator);
 procedure Initialize;
 
@@ -46,7 +48,7 @@ implementation
 
 uses
   SysUtils, Windows, Controls, StdCtrls, ComCtrls, Grids,
-  Config, ExprService, DataDir, FormUtils, GridUtils;
+  Config, ExprService, DataDir, FormUtils, GridUtils, CsvDocument;
 
 var
   _History:    TStringGrid;
@@ -54,6 +56,7 @@ var
   _Expression: TEdit;
   _VarList:    TStringGrid;
   _StatusBar:  TStatusBar;
+  FocusSet:    Boolean;
 
   {================ Private routines ================}
 
@@ -427,8 +430,50 @@ begin
     end;
 end;
 
+procedure SaveWorkspace;
+const
+  COL_KEY   = 0;
+  COL_VALUE = 1;
+  ROW_HEADER    = 0;
+  ROW_VARNAME    = 1;
+  ROW_EXPRESSION = 2;
 var
-  FocusSet: Boolean;
+  CSV:         TCSVDocument;
+  PathFilename: String;
+  TmpFilename: String;
+begin
+    try
+      begin
+      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+      TmpFilename  := PathFilename + '.tmp';
+
+      CSV           := TCSVDocument.Create;
+      CSV.Delimiter := ',';
+        try
+          begin
+          CSV.Cells[COL_KEY, ROW_HEADER]    := 'key';
+          CSV.Cells[COL_VALUE, ROW_HEADER]  := 'value';
+          CSV.Cells[COL_KEY, ROW_VARNAME]   := 'varname';
+          CSV.Cells[COL_VALUE, ROW_VARNAME] := _VarName.Text;
+          CSV.Cells[COL_KEY, ROW_EXPRESSION]   := 'expression';
+          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := _Expression.Text;
+          CSV.SaveToFile(TmpFilename);
+          end;
+        finally
+          begin
+          CSV.Free;
+          end;
+        end;
+
+      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
+        begin
+        SysUtils.DeleteFile(TmpFilename);
+        end;
+      end;
+    except
+      // Workspace save is best-effort; never surface errors to the user
+    end;
+end;
 
 procedure SetFocus;
 begin
@@ -452,6 +497,9 @@ begin
 end;
 
 procedure Initialize;
+var
+  PathFilename: String;
+  CSV:          TCSVDocument;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -475,6 +523,39 @@ begin
       begin
       StatusError(E.Message);
       end;
+    end;
+
+  // Restore workspace (best-effort, errors silently ignored)
+    try
+      begin
+      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+
+      // Clean up any stale temp file from a previous crashed save
+      if SysUtils.FileExists(PathFilename + '.tmp') then
+        SysUtils.DeleteFile(PathFilename + '.tmp');
+
+      if SysUtils.FileExists(PathFilename) then
+        begin
+        CSV           := TCSVDocument.Create;
+        CSV.Delimiter := ',';
+          try
+            begin
+            CSV.LoadFromFile(PathFilename);
+            // Row 0 is the header; data starts at row 1
+            if CSV.RowCount > 1 then
+              _VarName.Text := CSV.Cells[1, 1];
+            if CSV.RowCount > 2 then
+              _Expression.Text := CSV.Cells[1, 2];
+            end;
+          finally
+            begin
+            CSV.Free;
+            end;
+          end;
+        end;
+      end;
+    except
+      // Workspace restore is best-effort
     end;
 end;
 

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -39,6 +39,7 @@ procedure RemoveHistoryItem;
 procedure SetFocus;
 
 procedure SaveWorkspace;
+procedure SaveWindowPos;
 
 procedure Receive(const F: TCalculator);
 procedure Initialize;
@@ -56,6 +57,7 @@ var
   _Expression: TEdit;
   _VarList:    TStringGrid;
   _StatusBar:  TStatusBar;
+  _Form:       TCalculator;
   FocusSet:    Boolean;
 
   {================ Private routines ================}
@@ -435,6 +437,11 @@ begin
   Workspace.SaveWorkspace(_VarName.Text, _Expression.Text);
 end;
 
+procedure SaveWindowPos;
+begin
+  Workspace.SaveWindowPos(_Form.Left, _Form.Top, _Form.Width, _Form.Height);
+end;
+
 procedure SetFocus;
 begin
   if not FocusSet then
@@ -446,6 +453,7 @@ end;
 
 procedure Receive(const F: TCalculator);
 begin
+  _Form := F;
   with F do
     begin
     _History    := History;
@@ -459,6 +467,7 @@ end;
 procedure Initialize;
 var
   WS: TWorkspaceState;
+  WP: TWindowPos;
 begin
   _History.AutoFillColumns := True;
   _VarList.AutoFillColumns := True;
@@ -478,6 +487,12 @@ begin
       WS               := Workspace.LoadWorkspace;
       _VarName.Text    := WS.VarName;
       _Expression.Text := WS.Expression;
+
+      WP := Workspace.AdjustWindowPos(Workspace.LoadWindowPos);
+      if (WP.Width > 0) and (WP.Height > 0) then
+        begin
+        _Form.SetBounds(WP.Left, WP.Top, WP.Width, WP.Height);
+        end;
 
       StatusOK;
       end;

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -12,20 +12,43 @@ type
     Expression: String;
   end;
 
+  TWindowPos = record
+    Left:   Integer;
+    Top:    Integer;
+    Width:  Integer;
+    Height: Integer;
+  end;
+
 procedure SaveWorkspace(const VarName, Expression: String);
 function LoadWorkspace: TWorkspaceState;
+
+procedure SaveWindowPos(const Left, Top, Width, Height: Integer);
+function LoadWindowPos: TWindowPos;
+function AdjustWindowPos(const WP: TWindowPos): TWindowPos;
 
 implementation
 
 uses
-  SysUtils, Windows, CsvDocument,
+  SysUtils, Windows, Math, Forms, CsvDocument,
   Config, DataDir;
 
 const
-  COL_KEY        = 0;
-  COL_VALUE      = 1;
-  ROW_VARNAME    = 0;
-  ROW_EXPRESSION = 1;
+  CSV_COL: record
+    Key:   Byte;
+    Value: Byte;
+  end = (Key: 0; Value: 1);
+
+  WORKSPACE_ROWS: record
+    VarName:    Byte;
+    Expression: Byte;
+  end = (VarName: 0; Expression: 1);
+
+  WINPOS_ROWS: record
+    Left:   Byte;
+    Top:    Byte;
+    Width:  Byte;
+    Height: Byte;
+  end = (Left: 0; Top: 1; Width: 2; Height: 3);
 
 procedure SaveWorkspace(const VarName, Expression: String);
 var
@@ -42,10 +65,10 @@ begin
       CSV.Delimiter := ',';
         try
           begin
-          CSV.Cells[COL_KEY,   ROW_VARNAME]    := 'varname';
-          CSV.Cells[COL_VALUE, ROW_VARNAME]    := VarName;
-          CSV.Cells[COL_KEY,   ROW_EXPRESSION] := 'expression';
-          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := Expression;
+          CSV.Cells[CSV_COL.Key,   WORKSPACE_ROWS.VarName]    := 'varname';
+          CSV.Cells[CSV_COL.Value, WORKSPACE_ROWS.VarName]    := VarName;
+          CSV.Cells[CSV_COL.Key,   WORKSPACE_ROWS.Expression] := 'expression';
+          CSV.Cells[CSV_COL.Value, WORKSPACE_ROWS.Expression] := Expression;
           CSV.SaveToFile(TmpFilename);
           end;
         finally
@@ -87,11 +110,10 @@ begin
           try
             begin
             CSV.LoadFromFile(PathFilename);
-            // Row 0 is the header; data starts at row 1
-            if CSV.RowCount > ROW_VARNAME then
-              Result.VarName := CSV.Cells[COL_VALUE, ROW_VARNAME];
-            if CSV.RowCount > ROW_EXPRESSION then
-              Result.Expression := CSV.Cells[COL_VALUE, ROW_EXPRESSION];
+            if CSV.RowCount > WORKSPACE_ROWS.VarName then
+              Result.VarName := CSV.Cells[CSV_COL.Value, WORKSPACE_ROWS.VarName];
+            if CSV.RowCount > WORKSPACE_ROWS.Expression then
+              Result.Expression := CSV.Cells[CSV_COL.Value, WORKSPACE_ROWS.Expression];
             end;
           finally
             begin
@@ -103,6 +125,111 @@ begin
     except
       // Load is best-effort; return empty defaults on any error
     end;
+end;
+
+procedure SaveWindowPos(const Left, Top, Width, Height: Integer);
+var
+  CSV:          TCSVDocument;
+  PathFilename: String;
+  TmpFilename:  String;
+begin
+    try
+      begin
+      PathFilename := ForceDataDir(WINPOS_FILE.Dirname) + '\' + WINPOS_FILE.Filename;
+      TmpFilename  := PathFilename + '.tmp';
+
+      CSV           := TCSVDocument.Create;
+      CSV.Delimiter := ',';
+        try
+          begin
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Left]   := 'left';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Left]   := IntToStr(Left);
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Top]    := 'top';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Top]    := IntToStr(Top);
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Width]  := 'width';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Width]  := IntToStr(Width);
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Height] := 'height';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Height] := IntToStr(Height);
+          CSV.SaveToFile(TmpFilename);
+          end;
+        finally
+          begin
+          CSV.Free;
+          end;
+        end;
+
+      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
+        begin
+        SysUtils.DeleteFile(TmpFilename);
+        end;
+      end;
+    except
+      // Save is best-effort; never surface errors to the user
+    end;
+end;
+
+function LoadWindowPos: TWindowPos;
+var
+  PathFilename: String;
+  CSV:          TCSVDocument;
+begin
+  Result.Left   := 0;
+  Result.Top    := 0;
+  Result.Width  := 0;
+  Result.Height := 0;
+
+    try
+      begin
+      PathFilename := GetDataDir(WINPOS_FILE.Dirname) + '\' + WINPOS_FILE.Filename;
+
+      // Clean up any stale temp file from a previous crashed save
+      if SysUtils.FileExists(PathFilename + '.tmp') then
+        SysUtils.DeleteFile(PathFilename + '.tmp');
+
+      if SysUtils.FileExists(PathFilename) then
+        begin
+        CSV           := TCSVDocument.Create;
+        CSV.Delimiter := ',';
+          try
+            begin
+            CSV.LoadFromFile(PathFilename);
+            if CSV.RowCount > WINPOS_ROWS.Left   then Result.Left   := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Left],   0);
+            if CSV.RowCount > WINPOS_ROWS.Top    then Result.Top    := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Top],    0);
+            if CSV.RowCount > WINPOS_ROWS.Width  then Result.Width  := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Width],  0);
+            if CSV.RowCount > WINPOS_ROWS.Height then Result.Height := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Height], 0);
+            end;
+          finally
+            begin
+            CSV.Free;
+            end;
+          end;
+        end;
+      end;
+    except
+      // Load is best-effort; return zeroed defaults on any error
+    end;
+end;
+
+function AdjustWindowPos(const WP: TWindowPos): TWindowPos;
+var
+  Monitor:  TMonitor;
+  WorkArea: TRect;
+  Center:   TPoint;
+begin
+  Result := WP;
+
+  if (WP.Width <= 0) or (WP.Height <= 0) then
+    Exit;
+
+  // Find the monitor whose work area is nearest to the window centre
+  Center.X := WP.Left + WP.Width  div 2;
+  Center.Y := WP.Top  + WP.Height div 2;
+  Monitor  := Screen.MonitorFromPoint(Center);
+  WorkArea := Monitor.WorkareaRect;
+
+  // Clamp position so the window fits entirely within the work area
+  Result.Left := EnsureRange(WP.Left, WorkArea.Left, Max(WorkArea.Left, WorkArea.Right  - WP.Width));
+  Result.Top  := EnsureRange(WP.Top,  WorkArea.Top,  Max(WorkArea.Top,  WorkArea.Bottom - WP.Height));
 end;
 
 end.

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -1,0 +1,111 @@
+unit Workspace;
+
+{$mode ObjFPC}
+{$H+}
+{$inline ON}
+
+interface
+
+type
+  TWorkspaceState = record
+    VarName:    String;
+    Expression: String;
+  end;
+
+procedure SaveWorkspace(const VarName, Expression: String);
+function LoadWorkspace: TWorkspaceState;
+
+implementation
+
+uses
+  SysUtils, Windows, CsvDocument,
+  Config, DataDir;
+
+const
+  COL_KEY        = 0;
+  COL_VALUE      = 1;
+  ROW_HEADER     = 0;
+  ROW_VARNAME    = 1;
+  ROW_EXPRESSION = 2;
+
+procedure SaveWorkspace(const VarName, Expression: String);
+var
+  CSV:          TCSVDocument;
+  PathFilename: String;
+  TmpFilename:  String;
+begin
+    try
+      begin
+      PathFilename := ForceDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+      TmpFilename  := PathFilename + '.tmp';
+
+      CSV           := TCSVDocument.Create;
+      CSV.Delimiter := ',';
+        try
+          begin
+          CSV.Cells[COL_KEY,   ROW_HEADER]     := 'key';
+          CSV.Cells[COL_VALUE, ROW_HEADER]     := 'value';
+          CSV.Cells[COL_KEY,   ROW_VARNAME]    := 'varname';
+          CSV.Cells[COL_VALUE, ROW_VARNAME]    := VarName;
+          CSV.Cells[COL_KEY,   ROW_EXPRESSION] := 'expression';
+          CSV.Cells[COL_VALUE, ROW_EXPRESSION] := Expression;
+          CSV.SaveToFile(TmpFilename);
+          end;
+        finally
+          begin
+          CSV.Free;
+          end;
+        end;
+
+      if not MoveFileEx(PChar(TmpFilename), PChar(PathFilename), MOVEFILE_REPLACE_EXISTING) then
+        begin
+        SysUtils.DeleteFile(TmpFilename);
+        end;
+      end;
+    except
+      // Save is best-effort; never surface errors to the user
+    end;
+end;
+
+function LoadWorkspace: TWorkspaceState;
+var
+  PathFilename: String;
+  CSV:          TCSVDocument;
+begin
+  Result.VarName    := '';
+  Result.Expression := '';
+
+    try
+      begin
+      PathFilename := GetDataDir(WORKSPACE_FILE.Dirname) + '\' + WORKSPACE_FILE.Filename;
+
+      // Clean up any stale temp file from a previous crashed save
+      if SysUtils.FileExists(PathFilename + '.tmp') then
+        SysUtils.DeleteFile(PathFilename + '.tmp');
+
+      if SysUtils.FileExists(PathFilename) then
+        begin
+        CSV           := TCSVDocument.Create;
+        CSV.Delimiter := ',';
+          try
+            begin
+            CSV.LoadFromFile(PathFilename);
+            // Row 0 is the header; data starts at row 1
+            if CSV.RowCount > ROW_VARNAME then
+              Result.VarName := CSV.Cells[COL_VALUE, ROW_VARNAME];
+            if CSV.RowCount > ROW_EXPRESSION then
+              Result.Expression := CSV.Cells[COL_VALUE, ROW_EXPRESSION];
+            end;
+          finally
+            begin
+            CSV.Free;
+            end;
+          end;
+        end;
+      end;
+    except
+      // Load is best-effort; return empty defaults on any error
+    end;
+end;
+
+end.

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -6,25 +6,21 @@ unit Workspace;
 
 interface
 
+uses
+  Types;
+
 type
   TWorkspaceState = record
     VarName:    String;
     Expression: String;
   end;
 
-  TWindowPos = record
-    Left:   Integer;
-    Top:    Integer;
-    Width:  Integer;
-    Height: Integer;
-  end;
-
 procedure SaveWorkspace(const VarName, Expression: String);
 function LoadWorkspace: TWorkspaceState;
 
-procedure SaveWindowPos(const Left, Top, Width, Height: Integer);
-function LoadWindowPos: TWindowPos;
-function AdjustWindowPos(const WP: TWindowPos): TWindowPos;
+procedure SaveWindowPos(const Bounds: TRect);
+function LoadWindowPos: TRect;
+function AdjustWindowPos(const Bounds: TRect): TRect;
 
 implementation
 
@@ -46,9 +42,9 @@ const
   WINPOS_ROWS: record
     Left:   Byte;
     Top:    Byte;
-    Width:  Byte;
-    Height: Byte;
-  end = (Left: 0; Top: 1; Width: 2; Height: 3);
+    Right:  Byte;
+    Bottom: Byte;
+  end = (Left: 0; Top: 1; Right: 2; Bottom: 3);
 
 procedure SaveWorkspace(const VarName, Expression: String);
 var
@@ -127,7 +123,7 @@ begin
     end;
 end;
 
-procedure SaveWindowPos(const Left, Top, Width, Height: Integer);
+procedure SaveWindowPos(const Bounds: TRect);
 var
   CSV:          TCSVDocument;
   PathFilename: String;
@@ -143,13 +139,13 @@ begin
         try
           begin
           CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Left]   := 'left';
-          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Left]   := IntToStr(Left);
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Left]   := IntToStr(Bounds.Left);
           CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Top]    := 'top';
-          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Top]    := IntToStr(Top);
-          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Width]  := 'width';
-          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Width]  := IntToStr(Width);
-          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Height] := 'height';
-          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Height] := IntToStr(Height);
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Top]    := IntToStr(Bounds.Top);
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Right]  := 'right';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Right]  := IntToStr(Bounds.Right);
+          CSV.Cells[CSV_COL.Key,   WINPOS_ROWS.Bottom] := 'bottom';
+          CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Bottom] := IntToStr(Bounds.Bottom);
           CSV.SaveToFile(TmpFilename);
           end;
         finally
@@ -168,15 +164,15 @@ begin
     end;
 end;
 
-function LoadWindowPos: TWindowPos;
+function LoadWindowPos: TRect;
 var
   PathFilename: String;
   CSV:          TCSVDocument;
 begin
   Result.Left   := 0;
   Result.Top    := 0;
-  Result.Width  := 0;
-  Result.Height := 0;
+  Result.Right  := 0;
+  Result.Bottom := 0;
 
     try
       begin
@@ -195,8 +191,8 @@ begin
             CSV.LoadFromFile(PathFilename);
             if CSV.RowCount > WINPOS_ROWS.Left   then Result.Left   := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Left],   0);
             if CSV.RowCount > WINPOS_ROWS.Top    then Result.Top    := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Top],    0);
-            if CSV.RowCount > WINPOS_ROWS.Width  then Result.Width  := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Width],  0);
-            if CSV.RowCount > WINPOS_ROWS.Height then Result.Height := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Height], 0);
+            if CSV.RowCount > WINPOS_ROWS.Right  then Result.Right  := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Right],  0);
+            if CSV.RowCount > WINPOS_ROWS.Bottom then Result.Bottom := StrToIntDef(CSV.Cells[CSV_COL.Value, WINPOS_ROWS.Bottom], 0);
             end;
           finally
             begin
@@ -210,26 +206,32 @@ begin
     end;
 end;
 
-function AdjustWindowPos(const WP: TWindowPos): TWindowPos;
+function AdjustWindowPos(const Bounds: TRect): TRect;
 var
   Monitor:  TMonitor;
   WorkArea: TRect;
   Center:   TPoint;
+  W, H:     Integer;
 begin
-  Result := WP;
+  Result := Bounds;
 
-  if (WP.Width <= 0) or (WP.Height <= 0) then
+  W := Bounds.Right  - Bounds.Left;
+  H := Bounds.Bottom - Bounds.Top;
+
+  if (W <= 0) or (H <= 0) then
     Exit;
 
   // Find the monitor whose work area is nearest to the window centre
-  Center.X := WP.Left + WP.Width  div 2;
-  Center.Y := WP.Top  + WP.Height div 2;
+  Center.X := Bounds.Left + W div 2;
+  Center.Y := Bounds.Top  + H div 2;
   Monitor  := Screen.MonitorFromPoint(Center);
   WorkArea := Monitor.WorkareaRect;
 
   // Clamp position so the window fits entirely within the work area
-  Result.Left := EnsureRange(WP.Left, WorkArea.Left, Max(WorkArea.Left, WorkArea.Right  - WP.Width));
-  Result.Top  := EnsureRange(WP.Top,  WorkArea.Top,  Max(WorkArea.Top,  WorkArea.Bottom - WP.Height));
+  Result.Left := EnsureRange(Bounds.Left, WorkArea.Left, Max(WorkArea.Left, WorkArea.Right  - W));
+  Result.Top  := EnsureRange(Bounds.Top,  WorkArea.Top,  Max(WorkArea.Top,  WorkArea.Bottom - H));
+  Result.Right  := Result.Left + W;
+  Result.Bottom := Result.Top  + H;
 end;
 
 end.

--- a/src/utils/workspace.pas
+++ b/src/utils/workspace.pas
@@ -24,9 +24,8 @@ uses
 const
   COL_KEY        = 0;
   COL_VALUE      = 1;
-  ROW_HEADER     = 0;
-  ROW_VARNAME    = 1;
-  ROW_EXPRESSION = 2;
+  ROW_VARNAME    = 0;
+  ROW_EXPRESSION = 1;
 
 procedure SaveWorkspace(const VarName, Expression: String);
 var
@@ -43,8 +42,6 @@ begin
       CSV.Delimiter := ',';
         try
           begin
-          CSV.Cells[COL_KEY,   ROW_HEADER]     := 'key';
-          CSV.Cells[COL_VALUE, ROW_HEADER]     := 'value';
           CSV.Cells[COL_KEY,   ROW_VARNAME]    := 'varname';
           CSV.Cells[COL_VALUE, ROW_VARNAME]    := VarName;
           CSV.Cells[COL_KEY,   ROW_EXPRESSION] := 'expression';


### PR DESCRIPTION
Closes #4.

## Summary

- Add `SaveWindowPos` / `LoadWindowPos` to `workspace.pas`; window position is saved atomically on every `FormMove` / `FormResize` event and restored in `CalcService.Initialize`via `AdjustWindowPos` (clamps to nearest monitor work area).
- Add `WINPOS_FILE` constant to `config.pas`.
- Replace flat index literals with typed constant records (`CSV_COL`, `WORKSPACE_ROWS`, `WINPOS_ROWS`).
- Refactor: replace custom `TWindowPos` record with `TRect` (`Left`/`Top`/`Right`/`Bottom`), matching `TForm.BoundsRect` directly.

## Commits
1. Persist and restore window position (closes #4)
2. Replace TWindowPos with TRect