### PR TITLE
Implement Ctrl+Z/Ctrl+Y undo/redo for Expression edit

### DIFF
--- a/src/form/mainform.lfm
+++ b/src/form/mainform.lfm
@@ -29,6 +29,7 @@ object Calculator: TCalculator
     ParentFont = False
     TabOrder = 1
     OnKeyDown = ExpressionKeyDown
+    OnChange = ExpressionChange
   end
   object VarName: TEdit
     Left = 8

--- a/src/form/mainform.pas
+++ b/src/form/mainform.pas
@@ -32,6 +32,7 @@ type
     procedure FormShow(Sender: TObject);
 
     procedure ExpressionKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
+    procedure ExpressionChange(Sender: TObject);
     procedure VarNameKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure HistoryKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
     procedure HistoryDblClick(Sender: TObject);
@@ -169,6 +170,14 @@ end;
 
 procedure TCalculator.ExpressionKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);
 begin
+  if IsKeyCombinationMatch(Key, Shift, [VK_Z], [ssCtrl]) then
+    begin
+    CalcService.UndoExpression;
+    end;
+  if IsKeyCombinationMatch(Key, Shift, [VK_Y], [ssCtrl]) then
+    begin
+    CalcService.RedoExpression;
+    end;
   if IsKeyCombinationMatch(Key, Shift, [VK_BACK], [ssCtrl]) then
     begin
     CalcService.DoCtrlBackspace;
@@ -204,6 +213,11 @@ begin
         SelectAllEditText(Expression);
         end;
     end;
+end;
+
+procedure TCalculator.ExpressionChange(Sender: TObject);
+begin
+  CalcService.ExpressionChange;
 end;
 
 procedure TCalculator.HistoryKeyDown(Sender: TObject; var Key: Word; Shift: TShiftState);

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -38,6 +38,10 @@ procedure RemoveHistoryItem;
 
 procedure SetFocus;
 
+procedure ExpressionChange;
+procedure UndoExpression;
+procedure RedoExpression;
+
 procedure Receive(const F: TCalculator);
 procedure Initialize;
 
@@ -48,6 +52,15 @@ uses
   SysUtils, Windows, Controls, StdCtrls, ComCtrls, Grids,
   Config, ExprService, DataDir, FormUtils, GridUtils;
 
+const
+  UNDO_MAX = 100;
+
+type
+  TExprState = record
+    Text:     String;
+    SelStart: Integer;
+  end;
+
 var
   _History:    TStringGrid;
   _VarName:    TEdit;
@@ -55,7 +68,54 @@ var
   _VarList:    TStringGrid;
   _StatusBar:  TStatusBar;
 
+  _UndoStack:        array[0..UNDO_MAX - 1] of TExprState;
+  _RedoStack:        array[0..UNDO_MAX - 1] of TExprState;
+  _UndoHead:         Integer;   { next write position }
+  _UndoCount:        Integer;
+  _RedoHead:         Integer;   { next write position }
+  _RedoCount:        Integer;
+  _SuppressUndoPush: Boolean;
+
   {================ Private routines ================}
+
+procedure UndoPush(const State: TExprState); inline;
+begin
+  _UndoStack[_UndoHead] := State;
+  _UndoHead  := (_UndoHead + 1) mod UNDO_MAX;
+  if _UndoCount < UNDO_MAX then Inc(_UndoCount);
+end;
+
+function UndoPop: TExprState; inline;
+begin
+  _UndoHead := (_UndoHead - 1 + UNDO_MAX) mod UNDO_MAX;
+  Result    := _UndoStack[_UndoHead];
+  Dec(_UndoCount);
+end;
+
+function UndoPeek: TExprState; inline;
+begin
+  Result := _UndoStack[(_UndoHead - 1 + UNDO_MAX) mod UNDO_MAX];
+end;
+
+procedure RedoPush(const State: TExprState); inline;
+begin
+  _RedoStack[_RedoHead] := State;
+  _RedoHead  := (_RedoHead + 1) mod UNDO_MAX;
+  if _RedoCount < UNDO_MAX then Inc(_RedoCount);
+end;
+
+function RedoPop: TExprState; inline;
+begin
+  _RedoHead := (_RedoHead - 1 + UNDO_MAX) mod UNDO_MAX;
+  Result    := _RedoStack[_RedoHead];
+  Dec(_RedoCount);
+end;
+
+function ExprState: TExprState; inline;
+begin
+  Result.Text     := _Expression.Text;
+  Result.SelStart := _Expression.SelStart;
+end;
 
 procedure StatusOK; inline;
 begin
@@ -468,6 +528,7 @@ begin
       LoadGrid(_VarList, VARS_FILE);
       UpsertVarList;
 
+      UndoPush(ExprState);
       StatusOK;
       end;
     except
@@ -478,5 +539,39 @@ begin
     end;
 end;
 
+procedure ExpressionChange;
+begin
+  if _SuppressUndoPush then Exit;
+  if (_UndoCount > 0) and (_Expression.Text = UndoPeek.Text) then Exit;
+  UndoPush(ExprState);
+  _RedoCount := 0;
+  _RedoHead  := 0;
+end;
+
+procedure UndoExpression;
+var
+  Prev: TExprState;
+begin
+  if _UndoCount < 2 then Exit;
+  RedoPush(UndoPop);
+  Prev := UndoPeek;
+  _SuppressUndoPush    := True;
+  _Expression.Text     := Prev.Text;
+  _Expression.SelStart := Prev.SelStart;
+  _SuppressUndoPush    := False;
+end;
+
+procedure RedoExpression;
+var
+  Next: TExprState;
+begin
+  if _RedoCount = 0 then Exit;
+  Next := RedoPop;
+  UndoPush(Next);
+  _SuppressUndoPush    := True;
+  _Expression.Text     := Next.Text;
+  _Expression.SelStart := Next.SelStart;
+  _SuppressUndoPush    := False;
+end;
 
 end.

--- a/src/services/calcservice.pas
+++ b/src/services/calcservice.pas
@@ -41,6 +41,7 @@ procedure SetFocus;
 procedure ExpressionChange;
 procedure UndoExpression;
 procedure RedoExpression;
+
 procedure SaveWorkspace;
 procedure SaveWindowPos;
 
@@ -543,10 +544,11 @@ begin
       LoadGrid(_VarList, VARS_FILE);
       UpsertVarList;
 
-      UndoPush(ExprState);
       WS               := Workspace.LoadWorkspace;
       _VarName.Text    := WS.VarName;
       _Expression.Text := WS.Expression;
+
+      UndoPush(ExprState);
 
       WP := Workspace.AdjustWindowPos(Workspace.LoadWindowPos);
       if (WP.Right > WP.Left) and (WP.Bottom > WP.Top) then


### PR DESCRIPTION
Closes #6.

## Summary

Custom undo/redo stack scoped to the Expression `TEdit` only.

**Design:**
- Circular buffer (`UNDO_MAX=100`) with O(1) push/pop using a head pointer
- Undo stack always holds current state as its top — no separate 'current state' tracker needed
- Dedup: skip push if text unchanged since last recorded state
- Caret position (`SelStart`) stored and restored alongside text
- `_SuppressUndoPush` flag prevents recursive pushes during restore

**Files changed:**
- `calcservice.pas`: `ExpressionChange`, `UndoExpression`, `RedoExpression` + circular-buffer helpers (`UndoPush`/`Pop`/`Peek`, `RedoPush`/`Pop`, `ExprState`)
- `mainform.pas`: `ExpressionChange` handler; Ctrl+Z/Y in `ExpressionKeyDown`
- `mainform.lfm`: `OnChange` on Expression wired to `ExpressionChange`